### PR TITLE
Change acl of a resource

### DIFF
--- a/webapp/src/adapters/solid/PODManager.ts
+++ b/webapp/src/adapters/solid/PODManager.ts
@@ -185,6 +185,7 @@ export default class PODManager {
     private async saveDataset(path:string, dataset:SolidDataset): Promise<void> {
         let fetch = this.sessionManager.getSessionFetch();
         await saveSolidDatasetAt(path, dataset, {fetch: fetch});
+        await this.createAcl(path);
     }
 
     /**

--- a/webapp/src/adapters/solid/PODManager.ts
+++ b/webapp/src/adapters/solid/PODManager.ts
@@ -19,6 +19,35 @@ export default class PODManager {
             .catch(() => {return false});
     }
 
+    public async createAcl(path:string) {
+        let fetch = {fetch:this.sessionManager.getSessionFetch()};
+        let dataset = await getSolidDatasetWithAcl(path, fetch);
+        let linkedResources = getLinkedResourceUrlAll(dataset);
+        let fallbackAcl = getFallbackAcl(dataset);
+
+        let resourceInfo = {
+            sourceIri: path, 
+            isRawData: false, 
+            linkedResources: linkedResources,
+            aclUrl: path + '.acl' 
+        };
+
+        let acl = createAclFromFallbackAcl(
+            this.getResourceWithFallbackAcl(resourceInfo, fallbackAcl)
+        );
+        await saveAclFor({internal_resourceInfo: resourceInfo}, acl, fetch);
+    }
+
+    private getResourceWithFallbackAcl(resourceInfo:any, fallbackAcl:any):any {
+        return {
+            internal_resourceInfo: resourceInfo,
+            internal_acl: { 
+                resourceAcl: null, 
+                fallbackAcl: fallbackAcl 
+            }
+        }
+    }
+
     /**
      * Saves a map to the user's POD
      * 

--- a/webapp/src/adapters/solid/PODManager.ts
+++ b/webapp/src/adapters/solid/PODManager.ts
@@ -1,10 +1,11 @@
 import { QueryEngine } from '@comunica/query-sparql-solid';
-import { saveSolidDatasetAt, SolidDataset } from '@inrupt/solid-client';
+import { createAclFromFallbackAcl, getFallbackAcl, getLinkedResourceUrlAll, getSolidDatasetWithAcl, saveAclFor, saveSolidDatasetAt, SolidDataset, WithAccessibleAcl, WithAcl, WithFallbackAcl, WithResourceInfo, WithServerResourceInfo } from '@inrupt/solid-client';
 import Map from '../../domain/Map';
 import Assembler from './Assembler';
 import SolidSessionManager from './SolidSessionManager';
 import Placemark from '../../domain/Placemark';
 import Place from '../../domain/Place';
+import { universalAccess as access } from "@inrupt/solid-client";
 
 export default class PODManager {
     private sessionManager: SolidSessionManager  = SolidSessionManager.getManager();
@@ -32,6 +33,14 @@ export default class PODManager {
             .catch(() => {return false});
     }
 
+    public async setPublicAccess(resourceUrl:string, isPublic:boolean) {
+        await access.setPublicAccess(
+            resourceUrl,
+            { read: isPublic },
+            { fetch: this.sessionManager.getSessionFetch() },
+        );
+    }
+
     public async loadPlacemarks(map: Map): Promise<void> {
         let path:string = this.getBaseUrl() + '/data/maps/' + map.getId();
         let placemarks = await this.getPlacemarks(path);
@@ -49,6 +58,7 @@ export default class PODManager {
 
         let urls = await this.getContainedUrls(path);
         let maps = await this.getMapPreviews(urls);
+        console.log(maps)
         return maps;
     }
 

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -29,7 +29,7 @@ export default class Home extends React.Component<HomeProps,{data:Map|undefined}
             data: undefined
         };
         
-        let map = new Map();
+        let map = new Map("Public map");
         let places : Array<PlaceType> = props.placeList;
         let placemarks : Array<Placemark> = places.map((place) => {
             return new Placemark(place.latitude, place.longitude, place.title);
@@ -76,6 +76,8 @@ export default class Home extends React.Component<HomeProps,{data:Map|undefined}
                     </select>
                     <LeafletMapAdapter map={this.state.data}/>
                 </div>}
+                <input type="button" value="set public" onClick={async () => {await this.podManager.setPublicAccess(this.podManager.getBaseUrl()+"/data/maps/", true)}} />
+                <input type="button" value="set private" onClick={async () => {await this.podManager.setPublicAccess(this.podManager.getBaseUrl()+"/data/maps/", false)}} />
             </section>
         );
     }

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -76,8 +76,8 @@ export default class Home extends React.Component<HomeProps,{data:Map|undefined}
                     </select>
                     <LeafletMapAdapter map={this.state.data}/>
                 </div>}
-                <input type="button" value="set public" onClick={async () => {await this.podManager.setPublicAccess(this.podManager.getBaseUrl()+"/data/maps/", true)}} />
-                <input type="button" value="set private" onClick={async () => {await this.podManager.setPublicAccess(this.podManager.getBaseUrl()+"/data/maps/", false)}} />
+                <input type="button" value="set public" onClick={async () => {await this.podManager.setPublicAccess(this.podManager.getBaseUrl()+"/data/maps/"+this.maps[0].getId(), true)}} />
+                <input type="button" value="set private" onClick={async () => {await this.podManager.setPublicAccess(this.podManager.getBaseUrl()+"/data/maps/"+this.maps[0].getId(), false)}} />
             </section>
         );
     }


### PR DESCRIPTION
Added methods for changing the public access permissions of a resource.
When the datasets for the maps and places are created, they do not have any acl. For this reason, a new acl is created with their parent's permissions when they are added to the POD.