### PR TITLE
Refactor PODManager

### DIFF
--- a/webapp/src/adapters/solid/PODManager.ts
+++ b/webapp/src/adapters/solid/PODManager.ts
@@ -1,181 +1,22 @@
-import { QueryEngine } from '@comunica/query-sparql-solid';
-import { buildThing, createAclFromFallbackAcl, createSolidDataset, createThing, getFallbackAcl, getFileWithAcl, getLinkedResourceUrlAll, getSolidDataset, getSolidDatasetWithAcl, getThing, overwriteFile, saveAclFor, saveSolidDatasetAt, setPublicDefaultAccess, setThing, SolidDataset, Thing, WithAccessibleAcl, WithAcl, WithFallbackAcl, WithResourceInfo, WithServerResourceInfo } from '@inrupt/solid-client';
 import Map from '../../domain/Map';
-import Assembler from './Assembler';
-import SolidSessionManager from './SolidSessionManager';
-import Placemark from '../../domain/Placemark';
 import Place from '../../domain/Place';
-import { universalAccess as access } from "@inrupt/solid-client";
 import PlaceComment from '../../domain/Place/PlaceComment';
 import PlaceRating from '../../domain/Place/PlaceRating';
-import FriendManager from './FriendManager';
-import User from '../../domain/User';
 import Group from '../../domain/Group';
-import { RDF, RDFS } from '@inrupt/vocab-common-rdf';
+import PlacesRepository from './repositories/PlacesRepository';
+import InteractionsRepository from './repositories/InteractionsRepository';
+import MapsRepository from './repositories/MapsRepository';
+import GroupsRepository from './repositories/GroupsRepository';
 
 export default class PODManager {
-    private sessionManager: SolidSessionManager  = SolidSessionManager.getManager();
-    private friends: FriendManager = new FriendManager();
+
+    private maps: MapsRepository = new MapsRepository();
+    private places: PlacesRepository = new PlacesRepository();
+    private interactions: InteractionsRepository = new InteractionsRepository();
+    private groups: GroupsRepository = new GroupsRepository();
 
 
-    public async savePlace(place:Place): Promise<void> {
-        let path:string = this.getBaseUrl() + '/data/places/' + place.uuid;
-
-        await this.saveDataset(path+"/details", Assembler.placeToDataset(place));
-        await this.saveDataset(path+"/comments", createSolidDataset(), true);
-        await this.saveDataset(path+"/images", createSolidDataset(), true);
-        await this.saveDataset(path+"/reviews", createSolidDataset(), true);
-        await this.createAcl(path+'/');
-        place.photos.forEach(async img => await this.addImage(img, place));
-    }
-
-    public async comment(comment: PlaceComment, place: Place) {
-        let commentPath: string = this.getBaseUrl() + "/data/interactions/comments/"+comment.id;
-        await this.addCommentToUser(comment);
-        await this.addCommentToPlace(place.uuid, commentPath);
-    }
-
-    private async addCommentToUser(comment: PlaceComment) {
-        let commentPath: string = this.getBaseUrl() + "/data/interactions/comments/" + comment.id;
-        await this.saveDataset(commentPath, Assembler.commentToDataset(comment), true);
-        await this.setPublicAccess(commentPath, true);
-    }
-
-    private async addCommentToPlace(placeId: string, commentUrl: string) {
-        let commentsPath: string = this.getBaseUrl() + "/data/places/" + placeId + "/comments";
-        let placeComments = await getSolidDataset(commentsPath, {fetch: this.sessionManager.getSessionFetch()});
-
-        placeComments = setThing(placeComments, Assembler.urlToReference(commentUrl))
-        await this.saveDataset(commentsPath, placeComments);
-    }
-
-    public async getComments(placeUrl: string) {
-        let engine = new QueryEngine();
-        engine.invalidateHttpCache();
-        let query = `
-            PREFIX schema: <http://schema.org/>
-            SELECT DISTINCT ?url
-            WHERE {
-                ?s schema:URL ?url .
-            }
-        `;
-        let result = await engine.queryBindings(query, this.getQueryContext([placeUrl+"/comments"]));
-        let urls: string[] = [];
-        await result.toArray().then(r => {
-            urls = r.map(binding => binding.get("url")?.value as string);
-        });
-
-        query = `
-            PREFIX schema: <http://schema.org/>
-            SELECT DISTINCT ?user ?comment ?id
-            WHERE {
-                ?s schema:accountId ?user ;
-                   schema:description ?comment ;
-                   schema:identifier ?id .
-            }
-        `;
-        result = await engine.queryBindings(query, this.getQueryContext(urls));
-        return await result.toArray().then(r => {
-            return Assembler.toPlaceComments(r);
-        });
-        
-    }
-
-    public async addImage(image: File, place: Place) {
-        let imagePath: string = this.getBaseUrl() + "/data/interactions/images/"+ crypto.randomUUID();
-        await this.addImageToUser(image, imagePath);
-        await this.addImageToPlace(place.uuid, imagePath);
-    }
-
-    private async addImageToUser(image: File, imageUrl: string) {
-        try {
-            await overwriteFile(
-                imageUrl,
-                image,
-                {contentType: image.type, fetch: this.sessionManager.getSessionFetch()}
-            );
-            await this.createFileAcl(imageUrl)
-            await this.setPublicAccess(imageUrl, true);
-        } catch (err) {
-            console.log(err);
-        }
-    }
-
-    private async addImageToPlace(placeId: string, imageUrl: string) {
-        let imagesPath: string = this.getBaseUrl() + "/data/places/" + placeId + "/images";
-        let placeImages = await getSolidDataset(imagesPath, {fetch: this.sessionManager.getSessionFetch()});
-
-        placeImages = setThing(placeImages, Assembler.urlToReference(imageUrl))
-        await this.saveDataset(imagesPath, placeImages);
-    }
-
-    public async getImageUrls(placeUrl: string) {
-        let engine = new QueryEngine();
-        engine.invalidateHttpCache();
-        let query = `
-            PREFIX schema: <http://schema.org/>
-            SELECT DISTINCT ?url
-            WHERE {
-                ?s schema:URL ?url .
-            }
-        `;
-        let result = await engine.queryBindings(query, this.getQueryContext([placeUrl+"/images"]));
-
-        return await result.toArray().then(r => {
-            console.log(r)
-            return r.map(binding => binding.get("url")?.value as string);
-        });
-    }
-
-    public async createAcl(path:string) {
-        let dataset = await getSolidDatasetWithAcl(path, {fetch:this.sessionManager.getSessionFetch()});
-        await this.createNewAcl(dataset, path);
-    }
-
-    public async createFileAcl(path:string) {
-        let file = await getFileWithAcl(path, {fetch:this.sessionManager.getSessionFetch()});
-        await this.createNewAcl(file, path);
-    }
-
-    public async setDefaultFolderPermissions(path:string, permissions:any) {
-        let fetch = {fetch:this.sessionManager.getSessionFetch()};
-        let folder = await getSolidDatasetWithAcl(path, fetch);
-        let acl = await this.createNewAcl(folder, path);
-
-        acl = setPublicDefaultAccess(acl, permissions);
-        await saveAclFor({internal_resourceInfo: this.getResourceInfo(path,folder)}, acl, fetch);
-    }
-
-    private async createNewAcl(resource:any, path:string) {
-        let fallbackAcl = getFallbackAcl(resource);
-        let resourceInfo = this.getResourceInfo(path, resource);
-
-        let acl = createAclFromFallbackAcl(
-            this.getResourceWithFallbackAcl(resourceInfo, fallbackAcl)
-        );
-        await saveAclFor({internal_resourceInfo: resourceInfo}, acl, {fetch:this.sessionManager.getSessionFetch()});
-        return acl;
-    }
-
-    private getResourceInfo(path:string, resource:any) {
-        let linkedResources = getLinkedResourceUrlAll(resource);
-        return {
-            sourceIri: path, 
-            isRawData: false, 
-            linkedResources: linkedResources,
-            aclUrl: path + '.acl' 
-        };
-    }
-
-    private getResourceWithFallbackAcl(resourceInfo:any, fallbackAcl:any):any {
-        return {
-            internal_resourceInfo: resourceInfo,
-            internal_acl: { 
-                resourceAcl: null, 
-                fallbackAcl: fallbackAcl 
-            }
-        }
-    }
+    // MAPS
 
     /**
      * Saves a map to the user's POD
@@ -184,138 +25,223 @@ export default class PODManager {
      * @returns wether the map could be saved
      */
     public async saveMap(map:Map): Promise<void> {
-        let path:string = this.getBaseUrl() + '/data/maps/' + map.getId();
-        let userMaps:string = this.getBaseUrl() + '/user/maps';
-        let urlThing = Assembler.urlToReference(path);
-
-        await this.saveDataset(path, Assembler.mapToDataset(map), true);
-
-        await getSolidDataset(userMaps, {fetch: this.sessionManager.getSessionFetch()})
-            .then(async dataset => {
-                await this.saveDataset(userMaps, setThing(dataset, urlThing));
-            }).catch(async () => {
-                await this.saveDataset(userMaps, setThing(createSolidDataset(), urlThing));
-            });
-    }
-
-    public async loadPlacemarks(map: Map, author:string=""): Promise<void> {
-        let path:string = this.getBaseUrl(author) + '/data/maps/' + map.getId();
-        let placemarks = await this.getPlacemarks(path);
-        map.setPlacemarks(placemarks);
+        await this.maps.saveMap(map);
     }
 
     /**
      * Returns the details of all the maps of the user.
      * The placemarks will not be loaded.
      * 
+     * @param user the webID of the owner of the maps
      * @returns an array of maps containing the details to be displayed as a preview
      */
     public async getAllMaps(user:string=""): Promise<Array<Map>> {
-        let path:string = this.getBaseUrl(user) + '/data/maps/';
+        return await this.maps.getAllMaps(user);
+    } 
 
-        let urls = await this.getContainedUrls(path);
-        let maps = await this.getMapPreviews(urls);
-        console.log(maps)
-        return maps;
+    /**
+     * Adds the placemarks stored in the POD to their map
+     * 
+     * @param map the map whose placemarks will be loaded 
+     * @param author the webID of the creator of the map
+     */
+    public async loadPlacemarks(map: Map, author:string=""): Promise<void> {
+        await this.maps.loadPlacemarks(map, author);
     }
 
+
+    // PLACES
+
+    /**
+     * Retrieves a place from the given url
+     * 
+     * @param url the url of the place
+     * @returns the Place object
+     */
     public async getPlace(url:string): Promise<Place> {
-        let engine = new QueryEngine();
-        let query = `
-            PREFIX schema: <http://schema.org/>
-            SELECT DISTINCT ?title ?desc ?lat ?lng ?id
-            WHERE {
-                ?place schema:name ?title ;
-                       schema:description ?desc ;
-                       schema:latitude ?lat ;
-                       schema:longitude ?lng ;  
-                       schema:identifier ?id .  
-            }
-        `;
-        let result = await engine.queryBindings(query, this.getQueryContext([url+"/details"]));
-        return await result.toArray().then(r => {return Assembler.toPlace(r[0]);});
+        return await this.places.getPlace(url);
     }
 
     /**
-     * Returns the urls of all the resources in the given path
+     * Retrieves all the available places of a user
      * 
-     * @param path the path in which the urls will be searched
-     * @returns the urls of all the resources in the given path
+     * @param webID the webID of the user
+     * @returns all the available places
      */
-    private async getContainedUrls(path: string): Promise<any[]> {
-        let engine = new QueryEngine();
-        let query = `
-            PREFIX ldp: <http://www.w3.org/ns/ldp#>
-            SELECT ?content
-            WHERE {
-                <${path}> ldp:contains ?content .
-            }
-        `;
-        let result = await engine.queryBindings(query, this.getQueryContext([path]));
-
-        return await result.toArray().then(r => {
-            return r.map(binding => binding.get("content"));
-        });
+    public async getAllUserPlaces(webID:string=""): Promise<Place[]> {
+        return await this.places.getAllUserPlaces(webID);
     }
 
     /**
-     * Maps the given urls to Map objects
+     * Saves a place on the user data folder
+     * @param place the place to be saved
+     */
+    public async savePlace(place:Place): Promise<void> {
+        let placeUrl = this.getBaseUrl() + "/data/places/" + place.uuid;
+        this.places.savePlace(place);
+        place.photos.forEach(async img => await this.interactions.addImage(img, placeUrl));
+    }
+
+    /**
+     * Changes the public access permissions for a place
+     * @param place 
+     * @param isPublic 
+     */
+    public async changePlacePublicAccess(place:Place, isPublic:boolean) {
+        await this.places.changePlacePublicAccess(place, isPublic);
+    }
+
+
+    // INTERACTIONS
+
+    /**
+     * Adds a comment to a place
      * 
-     * @param urls the urls of the map datasets
-     * @returns an array of Map objects with the details of each map
+     * @param comment the comment to be added
+     * @param placeUrl the url of the place
      */
-    private async getMapPreviews(urls: Array<string>): Promise<Array<Map>> {
-        let engine = new QueryEngine();
-        let query = `
-            PREFIX schema: <http://schema.org/>
-            SELECT DISTINCT ?id ?name ?desc
-            WHERE {  
-                ?details schema:identifier ?id ;
-                         schema:name ?name ;
-                         schema:description ?desc .  
-            }
-        `;
-        let result = await engine.queryBindings(query, this.getQueryContext(urls));
-        return await result.toArray().then(r => {return Assembler.toMapPreviews(r);});
-    }
-
-    private async getPlacemarks(mapURL:string): Promise<Array<Placemark>> {
-        let engine = new QueryEngine();
-        let query = `
-            PREFIX schema: <http://schema.org/>
-            SELECT DISTINCT ?title ?lat ?lng ?placeUrl ?cat
-            WHERE {
-                ?placemark schema:name ?title ;
-                           schema:latitude ?lat ;
-                           schema:longitude ?lng ;  
-                           schema:url ?placeUrl ; 
-                           schema:description ?cat . 
-            }
-        `;
-        let result = await engine.queryBindings(query, this.getQueryContext([mapURL]));
-        return await result.toArray().then(r => {return Assembler.toPlacemarkArray(r);});
+    public async comment(comment: PlaceComment, placeUrl: string) {
+        await this.interactions.comment(comment, placeUrl);
     }
 
     /**
-     * @param sources the sources for the SPARQL query
-     * @returns the context for the query
-     */
-    private getQueryContext(sources: Array<string>): any {
-        return {sources: sources, fetch: this.sessionManager.getSessionFetch() }
-    }
-
-    /**
-     * Saves a dataset in the user's POD
+     * Retrieves all the comments of a place
      * 
-     * @param path the URI of the dataset
-     * @param dataset the dataset to be saved
+     * @param placeUrl the url of the place 
+     * @returns the comments of the place
      */
-    private async saveDataset(path:string, dataset:SolidDataset, createAcl:boolean=false): Promise<void> {
-        let fetch = this.sessionManager.getSessionFetch();
-        await saveSolidDatasetAt(path, dataset, {fetch: fetch});
-        if (createAcl) {
-            await this.createAcl(path);
-        }
+    public async getComments(placeUrl: string): Promise<PlaceComment[]> {
+        return await this.interactions.getComments(placeUrl);
+    }
+
+    /**
+     * Adds a review to a place
+     * 
+     * @param review the review to be added 
+     * @param placeUrl the url of the place
+     */
+    public async review(review: PlaceRating, placeUrl: string) {
+        await this.interactions.review(review, placeUrl);
+    }
+
+    /**
+     * Retrieves the average score of a place
+     * 
+     * @param placeUrl the url of the place
+     * @returns the average score and number of reviews
+     */
+    public async getScore(placeUrl: string) {
+        return await this.interactions.getScore(placeUrl);
+    }
+
+    /**
+     * Adds an image to a place
+     * 
+     * @param image the image to be added
+     * @param placeUrl the url of the place
+     */
+    public async addImage(image: File, placeUrl: string) {
+        await this.interactions.addImage(image, placeUrl);
+    }
+
+    /**
+     * Retrieves the urls of all the images of the place
+     * 
+     * @param placeUrl the url of the place
+     * @returns the urls of the place images
+     */
+    public async getImageUrls(placeUrl: string) { 
+        return await this.interactions.getImageUrls(placeUrl);
+    }
+
+
+    // GROUPS
+
+    /**
+     * Returns the group stored in the given url
+     * @param groupUrl the url of the group
+     * @returns the group object
+     */
+    public async getGroup(groupUrl: string): Promise<Group> {
+        return await this.groups.getGroup(groupUrl);
+    }
+
+    /**
+     * Retrieves all the groups of the user
+     * @returns the groups of the user
+     */
+    public async getAllUserGroups(): Promise<Group[]> {
+        return this.groups.getAllUserGroups();
+    }
+
+    /**
+     * Creates the friends group with the inrupt friends
+     */
+    public async createFriendsGroup(): Promise<void> {
+        await this.groups.createFriendsGroup();
+    }
+
+    /**
+     * Creates a new group in the PODs of all its members
+     * @param group the group to be stored in the PODs
+     */
+    public async createGroup(group: Group) {
+        await this.groups.createGroup(group);
+    }
+
+    /**
+     * Adds a new map to a group of users
+     * @param map the map to be stored
+     * @param group the group of the map
+     */
+    public async addMapToGroup(map:Map, group:Group) {
+        await this.maps.saveMap(map);
+        await this.groups.storeMapInGroup(map, group);
+    }
+
+    /**
+     * Returns the maps of the group
+     * @param group the group whose maps will be retrieved
+     * @returns the mapsof the group
+     */
+    public async getGroupMaps(group: Group): Promise<Map[]> {
+        let urls = await this.groups.getGroupMapUrls(group);
+        return await this.maps.getMapPreviews(urls);
+    }
+
+
+    // PERMISSIONS
+
+    /**
+     * Sets the public read and write permissions of a resource
+     * 
+     * @param resourceUrl the url of the resource
+     * @param canRead whether the resource has public read permissions
+     * @param canWrite whether the resource has public write permissions
+     */
+    public async setPublicAccess(resourceUrl:string, canRead:boolean, canWrite:boolean=false) {
+        await this.maps.setPublicAccess(resourceUrl, canRead, canWrite);
+    }
+
+    /**
+     * Sets the resource permissions for all the users in the given group
+     * 
+     * @param resourceUrl the url of the resource
+     * @param group the group of users whose permissions will be modified
+     * @param permissions the new access permissions
+     */
+    public async setGroupAccess(resourceUrl:string, group:Group, permissions:any) {
+        await this.maps.setGroupAccess(resourceUrl, group, permissions);
+    }
+
+    /**
+     * Sets the default access permissions for the contents inside a folder
+     * 
+     * @param path the url of the folder
+     * @param permissions the new default permissions
+     */
+    public async setDefaultFolderPermissions(path:string, permissions:any) {
+        await this.maps.setDefaultFolderPermissions(path, permissions);
     }
 
     /**
@@ -324,208 +250,8 @@ export default class PODManager {
      * @param webID the webID of the POD's user
      * @returns the root URL of the POD
      */
-    public getBaseUrl(webID:string=''): string {
-        if (webID === '') {
-            webID = this.sessionManager.getWebID();
-        }
-        return webID.slice(0, webID.indexOf('/profile/card#me')) + '/lomap';
-    }
-
-
-    public async review(review: PlaceRating, place: Place) {
-        let reviewPath: string = this.getBaseUrl() + "/data/interactions/reviews/"+review.id;
-        await this.addReviewToUser(review);
-        await this.addReviewToPlace(place.uuid, reviewPath);
-    }
-
-    private async addReviewToUser(review: PlaceRating) {
-        let reviewPath: string = this.getBaseUrl() + "/data/interactions/reviews/" + review.id;
-        await this.saveDataset(reviewPath, Assembler.reviewToDataset(review), true);
-        await this.setPublicAccess(reviewPath, true);
-    }
-
-    private async addReviewToPlace(placeId: string, reviewUrl: string) {
-        let reviewsPath: string = this.getBaseUrl() + "/data/places/" + placeId + "/reviews";
-        let placeReviews = await getSolidDataset(reviewsPath, {fetch: this.sessionManager.getSessionFetch()});
-
-        placeReviews = setThing(placeReviews, Assembler.urlToReference(reviewUrl))
-        await this.saveDataset(reviewsPath, placeReviews);
-    }
-
-    public async getScore(placeUrl: string) {
-        let engine = new QueryEngine();
-        engine.invalidateHttpCache();
-        let query = `
-            PREFIX schema: <http://schema.org/>
-            SELECT DISTINCT ?url
-            WHERE {
-                ?s schema:URL ?url .
-            }
-        `;
-        let result = await engine.queryBindings(query, this.getQueryContext([placeUrl+"/reviews"]));
-        let urls: string[] = [];
-        await result.toArray().then(r => {
-            urls = r.map(binding => binding.get("url")?.value as string);
-        });
-
-        query = `
-            PREFIX schema: <http://schema.org/>
-            SELECT (COUNT(?user) as ?number) (AVG(?review) as ?score)
-            WHERE {
-                ?s schema:accountId ?user ;
-                   schema:value ?review ;
-                   schema:identifier ?id .
-            }
-        `;
-        result = await engine.queryBindings(query, this.getQueryContext(urls));
-        return await result.toArray().then(r => {
-            return {
-                reviews: Number(r[0].get("number")?.value),
-                score:   Number(r[0].get("score")?.value)
-            }
-        });
-        
-    }
-
-    public async createFriendsGroup(): Promise<void> {
-        let users: User[] = await this.friends.getFriendsList();
-        let group = new Group("Friends", users);
-        let groupsPath = this.getBaseUrl() + "/groups";
-        await this.saveDataset(groupsPath+"/friends", Assembler.groupToDataset(group));
-        await this.setDefaultFolderPermissions(groupsPath+"/", {read:true, write:true});
-        await this.setPublicAccess(groupsPath+"/", false, true);
-    }
-
-    public async createGroup(group: Group) {
-        let webID = this.sessionManager.getWebID();
-        let dataset = Assembler.groupToDataset(group);
-        await this.createGroupForUser(new User("", webID), group, dataset);
-
-        group.getMembers()
-                .filter(member => member.getWebId() !== webID)
-                .forEach(user => this.createGroupForUser(user, group, dataset));
-    }
-
-    private async createGroupForUser(user:User, group:Group, dataset:SolidDataset|undefined = undefined) {
-        let path = this.getBaseUrl(user.getWebId()) + "/groups/" + group.getId();
-        let groupDataset = dataset || Assembler.groupToDataset(group);
-        await this.saveDataset(path, groupDataset);
-    }
-
-    public async getGroup(groupUrl: string): Promise<Group> {
-        return (await this.getGroupsFromUrls([groupUrl]))[0];
-    }
-
-    public async getAllUserGroups(): Promise<Group[]> {
-        let urls = await this.getContainedUrls(this.getBaseUrl()+'/groups/');
-        return await this.getGroupsFromUrls(urls);
-    }
-
-    private async getGroupsFromUrls(urls:string[]) {
-        let engine = new QueryEngine();
-        engine.invalidateHttpCache();
-        let query = `
-            PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-            SELECT DISTINCT ?name ?id (GROUP_CONCAT(DISTINCT ?member; SEPARATOR=",") AS ?members)
-            WHERE {   
-                ?group vcard:Name ?name;
-                       vcard:hasUID ?id ;
-                       vcard:hasMember ?member .
-            } 
-            GROUP BY ?name ?id
-        `;
-        let result = await engine.queryBindings(query, this.getQueryContext(urls));
-
-        let groups:Group[] = []
-        await result.toArray().then(r => {
-            r.forEach(binding =>groups.push( Assembler.toGroup(binding) ));
-        });
-        return groups;
-    }
-
-
-    public async getGroupMaps(group: Group): Promise<Map[]> {
-        let webIDs = group.getMembers().map(m => m.getWebId());
-        let groupUrls = webIDs.map( id => this.getBaseUrl(id)+"/groups/"+group.getId() );
-        let engine = new QueryEngine();
-        engine.invalidateHttpCache();
-        let query = `
-            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-            SELECT DISTINCT ?mapUrl
-            WHERE {   
-                ?bag rdfs:member ?mapUrl .
-            } 
-        `;
-        let urls: string[] = [];
-        let result = await engine.queryBindings(query, this.getQueryContext(groupUrls));
-
-        return await result.toArray().then(r => {
-            urls = r.map(binding => binding.get("mapUrl")?.value as string);
-            console.log(urls)
-            return this.getMapPreviews(urls);
-        });
-    }
-
-    public async addMapToGroup(map:Map, group:Group) {
-        console.log("add map to group")
-        let url = this.getBaseUrl() + "/data/maps/" + map.getId();
-        let otherMembers = group.getMembers().filter(m => m.getWebId() !== this.sessionManager.getWebID());
-        let newGroup = new Group(group.getName(), otherMembers, group.getId());
-
-        await this.saveMap(map);
-        await this.setGroupAccess(url, newGroup, {read:true, write:true});
-        console.log("inserting references")
-        await this.insertMapReferences(url, group);
-        console.log("finished")
-        let maps = await this.getGroupMaps(group);
-        maps.forEach(m => console.log(m.getId() + " " + m.getName()))
-    }
-
-    private async insertMapReferences(mapUrl:string, group:Group): Promise<void> {
-        let url = this.getBaseUrl()+'/groups/'+group.getId();
-        let dataset = await getSolidDataset(url, {fetch: this.sessionManager.getSessionFetch()});
-        let maps = getThing(dataset, url+"#maps");
-        dataset = setThing(dataset, buildThing(maps||createThing())
-            .addStringNoLocale(RDFS.member, mapUrl)
-            .build());
-
-        await this.saveDataset(url, dataset);
-    }
-
-    public async setFriendsAccess(resourceUrl:string, canRead:boolean) {
-        let group = await this.getGroup(this.getBaseUrl() + "/groups/friends");
-        await this.setGroupAccess(resourceUrl, group, { read: canRead });
-    }
-
-    public async setGroupAccess(resourceUrl:string, group:Group, permissions:any) {
-        console.log("set permissions: " + group + resourceUrl)
-        for (let user of group.getMembers()) {
-            console.log(user)
-            await access.setAgentAccess(
-                resourceUrl,
-                user.getWebId(),
-                permissions,
-                { fetch: this.sessionManager.getSessionFetch() }
-            );
-        }
-    }
-
-    public async setPublicAccess(resourceUrl:string, canRead:boolean, canWrite:boolean=false) {
-        await access.setPublicAccess(
-            resourceUrl,
-            { read: canRead, write: canWrite },
-            { fetch: this.sessionManager.getSessionFetch() },
-        );
-    }
-
-    public async changePlacePublicAccess(place:Place, isPublic:boolean) {
-        let path:string = this.getBaseUrl() + '/data/places/' + place.uuid;
-
-        await this.setPublicAccess(path+"/", isPublic);
-        for (let dataset of ['/images', '/comments', '/reviews']) {
-            await this.setPublicAccess(path + dataset, true, true);
-        }
+    public getBaseUrl(webID:string="") {
+        return this.maps.getBaseUrl(webID);
     }
 
 }

--- a/webapp/src/adapters/solid/repositories/AbstractSolidRepository.ts
+++ b/webapp/src/adapters/solid/repositories/AbstractSolidRepository.ts
@@ -164,7 +164,7 @@ export default abstract class AbstractSolidRepository {
         let result = await engine.queryBindings(query, this.getQueryContext([path]));
 
         return await result.toArray().then(r => {
-            return r.map(binding => binding.get("content"));
+            return r.map(binding => binding.get("content")?.value as string);
         });
     }
 

--- a/webapp/src/adapters/solid/repositories/AbstractSolidRepository.ts
+++ b/webapp/src/adapters/solid/repositories/AbstractSolidRepository.ts
@@ -1,0 +1,179 @@
+import SolidSessionManager from '../SolidSessionManager';
+import FriendManager from '../FriendManager';
+import { SolidDataset, createAclFromFallbackAcl, getFallbackAcl, getFileWithAcl, getLinkedResourceUrlAll, getSolidDatasetWithAcl, saveAclFor, saveSolidDatasetAt, setPublicDefaultAccess } from '@inrupt/solid-client';
+import { universalAccess as access } from "@inrupt/solid-client";
+import Group from '../../../domain/Group';
+import { QueryEngine } from '@comunica/query-sparql-solid';
+
+export default abstract class AbstractSolidRepository {
+
+    protected sessionManager: SolidSessionManager  = SolidSessionManager.getManager();
+    protected friends: FriendManager = new FriendManager();
+    protected fetch: any = {fetch:this.sessionManager.getSessionFetch()};
+
+
+    // ACL CREATION
+
+    /**
+     * Creates a new acl for a RDF resource
+     * @param path the url of the resource
+     */
+    public async createAcl(path:string) {
+        let dataset = await getSolidDatasetWithAcl(path, this.fetch);
+        await this.createNewAcl(dataset, path);
+    }
+
+    /**
+     * Creates a new acl for a non RDF file
+     * @param path the url of the file
+     */
+    public async createFileAcl(path:string) {
+        let file = await getFileWithAcl(path, this.fetch);
+        await this.createNewAcl(file, path);
+    }
+
+    /**
+     * Creates an ACL for the given resource
+     * 
+     * @param resource the resource with ACL
+     * @param path the url of the resource
+     * @returns the new ACL
+     */
+    private async createNewAcl(resource:any, path:string) {
+        let fallbackAcl = getFallbackAcl(resource);
+        let resourceInfo = this.getResourceInfo(path, resource);
+
+        let acl = createAclFromFallbackAcl(
+            this.getResourceWithFallbackAcl(resourceInfo, fallbackAcl)
+        );
+        await saveAclFor({internal_resourceInfo: resourceInfo}, acl, this.fetch);
+        return acl;
+    }
+
+    private getResourceInfo(path:string, resource:any) {
+        let linkedResources = getLinkedResourceUrlAll(resource);
+        return {
+            sourceIri: path, 
+            isRawData: false, 
+            linkedResources: linkedResources,
+            aclUrl: path + '.acl' 
+        };
+    }
+
+    private getResourceWithFallbackAcl(resourceInfo:any, fallbackAcl:any):any {
+        return {
+            internal_resourceInfo: resourceInfo,
+            internal_acl: { 
+                resourceAcl: null, 
+                fallbackAcl: fallbackAcl 
+            }
+        }
+    }
+
+
+    // CHANGE ACCESS PERMISSIONS
+
+    /**
+     * Sets the public read and write permissions of a resource
+     * 
+     * @param resourceUrl the url of the resource
+     * @param canRead whether the resource has public read permissions
+     * @param canWrite whether the resource has public write permissions
+     */
+    public async setPublicAccess(resourceUrl:string, canRead:boolean, canWrite:boolean=false) {
+        await access.setPublicAccess(
+            resourceUrl,
+            { read: canRead, write: canWrite },
+            this.fetch,
+        );
+    }
+
+    /**
+     * Sets the resource permissions for all the users in the given group
+     * 
+     * @param resourceUrl the url of the resource
+     * @param group the group of users whose permissions will be modified
+     * @param permissions the new access permissions
+     */
+    public async setGroupAccess(resourceUrl:string, group:Group, permissions:any) {
+
+        for (let user of group.getMembers()) {
+            await access.setAgentAccess(resourceUrl, user.getWebId(), permissions, this.fetch);
+        }
+    }
+
+    /**
+     * Sets the default access permissions for the contents inside a folder
+     * 
+     * @param path the url of the folder
+     * @param permissions the new default permissions
+     */
+    public async setDefaultFolderPermissions(path:string, permissions:any) {
+        let folder = await getSolidDatasetWithAcl(path, this.fetch);
+        let acl = await this.createNewAcl(folder, path);
+
+        acl = setPublicDefaultAccess(acl, permissions);
+        await saveAclFor({internal_resourceInfo: this.getResourceInfo(path,folder)}, acl, this.fetch);  
+    }
+
+
+    // UTILITIES
+
+    /**
+     * Returns the root url of a POD
+     * 
+     * @param webID the webID of the POD's user
+     * @returns the root URL of the POD
+     */
+    public getBaseUrl(webID:string=''): string {
+        if (webID === '') {
+            webID = this.sessionManager.getWebID();
+        }
+        return webID.slice(0, webID.indexOf('/profile/card#me')) + '/lomap';
+    }
+
+    /**
+     * Saves a dataset in the user's POD
+     * 
+     * @param path the URI of the dataset
+     * @param dataset the dataset to be saved
+     */
+    protected async saveDataset(path:string, dataset:SolidDataset, createAcl:boolean=false): Promise<void> {
+        await saveSolidDatasetAt(path, dataset, this.fetch);
+        if (createAcl) {
+            await this.createAcl(path);
+        }
+    }
+
+    /**
+     * Returns the urls of all the resources in the given path
+     * 
+     * @param path the path in which the urls will be searched
+     * @returns the urls of all the resources in the given path
+     */
+    protected async getContainedUrls(path: string): Promise<any[]> {
+        let engine = new QueryEngine();
+        engine.invalidateHttpCache();
+        let query = `
+            PREFIX ldp: <http://www.w3.org/ns/ldp#>
+            SELECT ?content
+            WHERE {
+                <${path}> ldp:contains ?content .
+            }
+        `;
+        let result = await engine.queryBindings(query, this.getQueryContext([path]));
+
+        return await result.toArray().then(r => {
+            return r.map(binding => binding.get("content"));
+        });
+    }
+
+    /**
+     * @param sources the sources for the SPARQL query
+     * @returns the context for the query
+     */
+    protected getQueryContext(sources: Array<string>): any {
+        return {sources: sources, fetch: this.sessionManager.getSessionFetch() }
+    }
+
+}

--- a/webapp/src/adapters/solid/repositories/GroupsRepository.ts
+++ b/webapp/src/adapters/solid/repositories/GroupsRepository.ts
@@ -1,0 +1,136 @@
+import { QueryEngine } from "@comunica/query-sparql-solid";
+import Group from "../../../domain/Group";
+import User from "../../../domain/User";
+import Assembler from "../Assembler";
+import Map from '../../../domain/Map';
+import AbstractSolidRepository from "./AbstractSolidRepository";
+import { SolidDataset, buildThing, createThing, getSolidDataset, getThing, setThing } from "@inrupt/solid-client";
+import { RDFS } from "@inrupt/vocab-common-rdf";
+
+export default class GroupsRepository extends AbstractSolidRepository {
+
+    /**
+     * Returns the group stored in the given url
+     * @param groupUrl the url of the group
+     * @returns the group object
+     */
+    public async getGroup(groupUrl: string): Promise<Group> {
+        return (await this.getGroupsFromUrls([groupUrl]))[0];
+    }
+
+    /**
+     * Retrieves all the groups of the user
+     * @returns the groups of the user
+     */
+    public async getAllUserGroups(): Promise<Group[]> {
+        let urls = await this.getContainedUrls(this.getBaseUrl()+'/groups');
+        return await this.getGroupsFromUrls(urls);
+    }
+
+    /**
+     * Creates the friends group with the inrupt friends
+     */
+    public async createFriendsGroup(): Promise<void> {
+        let users: User[] = await this.friends.getFriendsList();
+        let group = new Group("Friends", users); 
+        let groupsPath = this.getBaseUrl() + "/groups";
+
+        await this.saveDataset(groupsPath+"/friends", Assembler.groupToDataset(group));
+        await this.setDefaultFolderPermissions(groupsPath+"/", {read:true, write:true});
+        await this.setPublicAccess(groupsPath+"/", false, true);
+    }
+
+    /**
+     * Creates a new group in the PODs of all its members
+     * @param group the group to be stored in the PODs
+     */
+    public async createGroup(group: Group) {
+        let webID = this.sessionManager.getWebID();
+        let dataset = Assembler.groupToDataset(group);
+        await this.createGroupForUser(new User("", webID), group, dataset);
+
+        group.getMembers()
+                .filter(member => member.getWebId() !== webID)
+                .forEach(user => this.createGroupForUser(user, group, dataset));
+    }
+
+    /**
+     * Stores a map in the group maps thing
+     * @param map the map to be stored
+     * @param group the group of the map
+     */
+    public async storeMapInGroup(map:Map, group:Group) {
+        let url = this.getBaseUrl() + "/data/maps/" + map.getId();
+        let otherMembers = group.getMembers().filter(m => m.getWebId() !== this.sessionManager.getWebID());
+        let newGroup = new Group(group.getName(), otherMembers, group.getId());
+
+        await this.setGroupAccess(url, newGroup, {read:true, write:true});
+        await this.insertMapReferences(url, group);
+    }
+
+    /**
+     * Returns the urls of all the maps of the group
+     * @param group the group whose maps will be retrieved
+     * @returns the urls of the maps
+     */
+    public async getGroupMapUrls(group: Group): Promise<string[]> {
+        let webIDs = group.getMembers().map(m => m.getWebId());
+        let groupUrls = webIDs.map( id => this.getBaseUrl(id)+"/groups/"+group.getId() );
+
+        let engine = new QueryEngine();
+        engine.invalidateHttpCache();
+        let query = `
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            SELECT DISTINCT ?mapUrl
+            WHERE {   
+                ?bag rdfs:member ?mapUrl .
+            } 
+        `;
+        let result = await engine.queryBindings(query, this.getQueryContext(groupUrls));
+
+        return await result.toArray().then(r => {
+            return r.map(binding => binding.get("mapUrl")?.value as string);
+        });
+    }
+
+    
+    private async createGroupForUser(user:User, group:Group, dataset:SolidDataset|undefined = undefined) {
+        let path = this.getBaseUrl(user.getWebId()) + "/groups/" + group.getId();
+        let groupDataset = dataset || Assembler.groupToDataset(group);
+        await this.saveDataset(path, groupDataset);
+    }
+
+    private async getGroupsFromUrls(urls:string[]) {
+        let engine = new QueryEngine();
+        engine.invalidateHttpCache();
+        let query = `
+            PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+            SELECT DISTINCT ?name ?id (GROUP_CONCAT(DISTINCT ?member; SEPARATOR=",") AS ?members)
+            WHERE {   
+                ?group vcard:Name ?name;
+                       vcard:hasUID ?id ;
+                       vcard:hasMember ?member .
+            } 
+            GROUP BY ?name ?id
+        `;
+        let result = await engine.queryBindings(query, this.getQueryContext(urls));
+
+        let groups:Group[] = []
+        await result.toArray().then(r => {
+            r.forEach(binding =>groups.push( Assembler.toGroup(binding) ));
+        });
+        return groups;
+    }
+
+    private async insertMapReferences(mapUrl:string, group:Group): Promise<void> {
+        let url = this.getBaseUrl()+'/groups/'+group.getId();
+        let dataset = await getSolidDataset(url, this.fetch);
+        let maps = getThing(dataset, url+"#maps");
+        dataset = setThing(dataset, buildThing(maps||createThing())
+            .addStringNoLocale(RDFS.member, mapUrl)
+            .build());
+
+        await this.saveDataset(url, dataset);
+    }
+}

--- a/webapp/src/adapters/solid/repositories/InteractionsRepository.ts
+++ b/webapp/src/adapters/solid/repositories/InteractionsRepository.ts
@@ -1,0 +1,161 @@
+import { QueryEngine } from "@comunica/query-sparql-solid";
+import PlaceComment from "../../../domain/Place/PlaceComment";
+import Assembler from "../Assembler";
+import AbstractSolidRepository from "./AbstractSolidRepository";
+import { getSolidDataset, overwriteFile, setThing } from "@inrupt/solid-client";
+import PlaceRating from "../../../domain/Place/PlaceRating";
+
+export default class InteractionsRepository extends AbstractSolidRepository {
+
+    /**
+     * Adds a comment to a place
+     * 
+     * @param comment the comment to be added
+     * @param placeUrl the url of the place
+     */
+    public async comment(comment: PlaceComment, placeUrl: string) {
+        let commentPath: string = this.getBaseUrl() + "/data/interactions/comments/" + comment.id;
+        await this.addCommentToUser(comment);
+        await this.addInteractionToPlace(placeUrl+"/comments", commentPath);
+    }
+
+    /**
+     * Adds a review to a place
+     * 
+     * @param review the review to be added 
+     * @param placeUrl the url of the place
+     */
+    public async review(review: PlaceRating, placeUrl: string) {
+        let reviewPath: string = this.getBaseUrl() + "/data/interactions/reviews/"+review.id;
+        await this.addReviewToUser(review);
+        await this.addInteractionToPlace(placeUrl+"/reviews", reviewPath);
+    }
+
+    /**
+     * Adds an image to a place
+     * 
+     * @param image the image to be added
+     * @param placeUrl the url of the place
+     */
+    public async addImage(image: File, placeUrl: string) {
+        let imagePath = this.getBaseUrl() + "/data/interactions/images/" + crypto.randomUUID();
+        await this.addImageToUser(image, imagePath);
+        await this.addInteractionToPlace(placeUrl+"/images", imagePath)
+    }
+
+    /**
+     * Retrieves all the comments of a place
+     * 
+     * @param placeUrl the url of the place 
+     * @returns the comments of the place
+     */
+    public async getComments(placeUrl: string): Promise<PlaceComment[]> {
+        let urls = await this.getUrlsFromDataset(placeUrl + "/comments");
+
+        let engine = new QueryEngine();
+        engine.invalidateHttpCache();
+
+        let query = `
+            PREFIX schema: <http://schema.org/>
+            SELECT DISTINCT ?user ?comment ?id
+            WHERE {
+                ?s schema:accountId ?user ;
+                   schema:description ?comment ;
+                   schema:identifier ?id .
+            }
+        `;
+        let result = await engine.queryBindings(query, this.getQueryContext(urls));
+        return await result.toArray().then(r => {
+            return Assembler.toPlaceComments(r);
+        }); 
+    }
+
+    /**
+     * Retrieves the average score of a place
+     * 
+     * @param placeUrl the url of the place
+     * @returns the average score and number of reviews
+     */
+    public async getScore(placeUrl: string) {
+        let urls = await this.getUrlsFromDataset(placeUrl + "/reviews");
+
+        let engine = new QueryEngine();
+        engine.invalidateHttpCache();
+        let query = `
+            PREFIX schema: <http://schema.org/>
+            SELECT (COUNT(?user) as ?number) (AVG(?review) as ?score)
+            WHERE {
+                ?s schema:accountId ?user ;
+                   schema:value ?review ;
+                   schema:identifier ?id .
+            }
+        `;
+        let result = await engine.queryBindings(query, this.getQueryContext(urls));
+        return await result.toArray().then(r => {
+            return {
+                reviews: Number(r[0].get("number")?.value),
+                score:   Number(r[0].get("score")?.value)
+            }
+        });      
+    }
+
+    /**
+     * Retrieves the urls of all the images of the place
+     * 
+     * @param placeUrl the url of the place
+     * @returns the urls of the place images
+     */
+    public async getImageUrls(placeUrl: string) { 
+        return await this.getUrlsFromDataset(placeUrl + "/images");  
+    }
+
+    private async addInteractionToPlace(datasetUrl:string, interactionRef:string) {
+        let dataset = await getSolidDataset(datasetUrl, this.fetch);
+        dataset = setThing(dataset, Assembler.urlToReference(interactionRef))
+        await this.saveDataset(datasetUrl, dataset);
+    }
+
+    private async addCommentToUser(comment: PlaceComment) {
+        let commentPath: string = this.getBaseUrl() + "/data/interactions/comments/" + comment.id;
+        await this.saveDataset(commentPath, Assembler.commentToDataset(comment), true);
+        await this.setPublicAccess(commentPath, true);
+    }
+
+    private async addReviewToUser(review: PlaceRating) {
+        let reviewPath: string = this.getBaseUrl() + "/data/interactions/reviews/" + review.id;
+        await this.saveDataset(reviewPath, Assembler.reviewToDataset(review), true);
+        await this.setPublicAccess(reviewPath, true);
+    }
+
+    private async addImageToUser(image: File, imageUrl: string) {
+        try {
+            await overwriteFile(
+                imageUrl,
+                image,
+                {contentType: image.type, fetch: this.sessionManager.getSessionFetch()}
+            );
+            await this.createFileAcl(imageUrl)
+            await this.setPublicAccess(imageUrl, true);
+        } catch (err) {
+            console.log(err);
+        }
+    }
+
+    private async getUrlsFromDataset(datasetUrl:string): Promise<string[]> {
+        let engine = new QueryEngine();
+        engine.invalidateHttpCache();
+        let query = `
+            PREFIX schema: <http://schema.org/>
+            SELECT DISTINCT ?url
+            WHERE {
+                ?s schema:URL ?url .
+            }
+        `;
+        let result = await engine.queryBindings(query, this.getQueryContext([datasetUrl]));
+
+        return await result.toArray().then(r => {
+            return r.map(binding => binding.get("url")?.value as string);
+        });
+    }
+
+}

--- a/webapp/src/adapters/solid/repositories/MapsRepository.ts
+++ b/webapp/src/adapters/solid/repositories/MapsRepository.ts
@@ -1,0 +1,95 @@
+import Assembler from "../Assembler";
+import Map from '../../../domain/Map';
+import AbstractSolidRepository from "./AbstractSolidRepository";
+import { QueryEngine } from "@comunica/query-sparql-solid";
+import Placemark from "../../../domain/Placemark";
+
+export default class MapsRepository extends AbstractSolidRepository {
+    
+    /**
+     * Saves a map to the user's POD
+     * 
+     * @param map the map to be saved
+     * @returns wether the map could be saved
+     */
+    public async saveMap(map:Map): Promise<void> {
+        let path = this.getBaseUrl() + '/data/maps/' + map.getId();
+        await this.saveDataset(path, Assembler.mapToDataset(map), true);
+        /*
+        let userMaps = this.getBaseUrl() + '/user/maps';
+        let urlThing = Assembler.urlToReference(path);
+
+        await getSolidDataset(userMaps, this.fetch)
+            .then(async dataset => {
+                await this.saveDataset(userMaps, setThing(dataset, urlThing));
+            }).catch(async () => {
+                await this.saveDataset(userMaps, setThing(createSolidDataset(), urlThing));
+            });
+        */
+    }
+
+    /**
+     * Adds the placemarks stored in the POD to their map
+     * 
+     * @param map the map whose placemarks will be loaded 
+     * @param author the webID of the creator of the map
+     */
+    public async loadPlacemarks(map: Map, author:string=""): Promise<void> {
+        let path:string = this.getBaseUrl(author) + '/data/maps/' + map.getId();
+        let placemarks = await this.getPlacemarks(path);
+        map.setPlacemarks(placemarks);
+    }
+
+    /**
+     * Returns the details of all the maps of the user.
+     * The placemarks will not be loaded.
+     * 
+     * @param user the webID of the owner of the maps
+     * @returns an array of maps containing the details to be displayed as a preview
+     */
+    public async getAllMaps(user:string=""): Promise<Array<Map>> {
+        let path:string = this.getBaseUrl(user) + '/data/maps/';
+
+        let urls = await this.getContainedUrls(path);
+        let maps = await this.getMapPreviews(urls);
+        return maps;
+    } 
+
+    /**
+     * Maps the given urls to Map objects
+     * 
+     * @param urls the urls of the map datasets
+     * @returns an array of Map objects with the details of each map
+     */
+    public async getMapPreviews(urls: Array<string>): Promise<Array<Map>> {
+        let engine = new QueryEngine();
+        let query = `
+            PREFIX schema: <http://schema.org/>
+            SELECT DISTINCT ?id ?name ?desc
+            WHERE {  
+                ?details schema:identifier ?id ;
+                         schema:name ?name ;
+                         schema:description ?desc .  
+            }
+        `;
+        let result = await engine.queryBindings(query, this.getQueryContext(urls));
+        return await result.toArray().then(r => {return Assembler.toMapPreviews(r);});
+    }
+
+    private async getPlacemarks(mapURL:string): Promise<Array<Placemark>> {
+        let engine = new QueryEngine();
+        let query = `
+            PREFIX schema: <http://schema.org/>
+            SELECT DISTINCT ?title ?lat ?lng ?placeUrl ?cat
+            WHERE {
+                ?placemark schema:name ?title ;
+                           schema:latitude ?lat ;
+                           schema:longitude ?lng ;  
+                           schema:url ?placeUrl ; 
+                           schema:description ?cat . 
+            }
+        `;
+        let result = await engine.queryBindings(query, this.getQueryContext([mapURL]));
+        return await result.toArray().then(r => {return Assembler.toPlacemarkArray(r);});
+    }
+}

--- a/webapp/src/adapters/solid/repositories/PlacesRepository.ts
+++ b/webapp/src/adapters/solid/repositories/PlacesRepository.ts
@@ -1,0 +1,83 @@
+import { createSolidDataset } from "@inrupt/solid-client";
+import Place from "../../../domain/Place";
+import Assembler from "../Assembler";
+import AbstractSolidRepository from "./AbstractSolidRepository";
+import { QueryEngine } from "@comunica/query-sparql-solid";
+
+export default class PlacesRepository extends AbstractSolidRepository {
+
+    /**
+     * Retrieves a place from the given url
+     * 
+     * @param url the url of the place
+     * @returns the Place object
+     */
+    public async getPlace(url:string): Promise<Place> {
+        return (await this.getPlacesFromUrls([url]))[0]; 
+    }
+
+    /**
+     * Retrieves all the available places of a user
+     * 
+     * @param webID the webID of the user
+     * @returns all the available places
+     */
+    public async getAllUserPlaces(webID:string=""): Promise<Place[]> {
+        let urls = await this.getContainedUrls(this.getBaseUrl(webID)+'/data/places/');
+        return await this.getPlacesFromUrls(urls);
+    }
+
+    /**
+     * Saves a place on the user data folder
+     * @param place the place to be saved
+     */
+    public async savePlace(place:Place): Promise<void> {
+        let path:string = this.getBaseUrl() + '/data/places/' + place.uuid;
+
+        await this.saveDataset(path+"/details", Assembler.placeToDataset(place));
+        await this.saveDataset(path+"/comments", createSolidDataset(), true);
+        await this.saveDataset(path+"/images", createSolidDataset(), true);
+        await this.saveDataset(path+"/reviews", createSolidDataset(), true);
+        await this.createAcl(path+'/');
+        this.setPublicAccess(this.getBaseUrl()+'/data/places/', true);
+    }
+
+    /**
+     * Changes the public access permissions for a place
+     * @param place 
+     * @param isPublic 
+     */
+    public async changePlacePublicAccess(place:Place, isPublic:boolean) {
+        let path:string = this.getBaseUrl() + '/data/places/' + place.uuid;
+
+        await this.setPublicAccess(path+"/", isPublic);
+        for (let dataset of ['/images', '/comments', '/reviews']) {
+            await this.setPublicAccess(path + dataset, true, true);
+        }
+    }
+
+
+    private async getPlacesFromUrls(urls:string[]): Promise<Place[]> {
+        let engine = new QueryEngine();
+        engine.invalidateHttpCache();
+        let query = `
+            PREFIX schema: <http://schema.org/>
+            SELECT DISTINCT ?title ?desc ?lat ?lng ?id
+            WHERE {
+                ?place schema:name ?title ;
+                       schema:description ?desc ;
+                       schema:latitude ?lat ;
+                       schema:longitude ?lng ;  
+                       schema:identifier ?id .  
+            }
+        `;
+        let result = await engine.queryBindings(query, this.getQueryContext(urls.map(url => url+"/details")));
+
+        let places:Place[] = []
+        await result.toArray().then(r => {
+            r.forEach(binding =>places.push( Assembler.toPlace(binding) ));
+        });
+        return places;
+    }
+    
+}


### PR DESCRIPTION
The functionality has been split into several repositories. The PODManager is now a facade and the only change in its interface is that the full url of the place should be passed when creating interactions. This is due to a bug that wasn't allowing us to comment on other people places. 